### PR TITLE
Invert "Por que receber" and "O que precisamos" sections in MeetupPartnership

### DIFF
--- a/site/Build/parceria-meetup/index.html
+++ b/site/Build/parceria-meetup/index.html
@@ -236,6 +236,53 @@
               <div class="vstack" style="gap: 20px">
                 <div class="mb-0 align-self-start">
                   <div class="vstack" style="gap: 6px">
+                    <h2 class="mb-0 align-self-start">Por que receber um CocoaHeads</h2>
+                  </div>
+                </div>
+                <p class="mb-0 align-self-start">Receber um CocoaHeads é uma forma direta de se conectar com a comunidade de tecnologia da sua região:</p>
+                <div class="row g-3 mb-0 align-self-start">
+                  <div class="col-12 col-md-6">
+                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
+                      <p class="ch-headline mb-0 align-self-start">Networking e talentos</p>
+                      <p class="ch-subhead mb-0 align-self-start">Contato direto com desenvolvedores experientes e novos talentos da plataforma Apple — um público dedicado, que sai de casa para aprender e trocar com a comunidade</p>
+                    </div>
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
+                      <p class="ch-headline mb-0 align-self-start">Visibilidade qualificada</p>
+                      <p class="ch-subhead mb-0 align-self-start">Sua marca associada ao principal encontro de desenvolvedores Apple do Brasil, diante de um público técnico e engajado</p>
+                    </div>
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
+                      <p class="ch-headline mb-0 align-self-start">Espaço na agenda</p>
+                      <p class="ch-subhead mb-0 align-self-start">Um momento para apresentar sua organização, seus projetos ou oportunidades ao público presente</p>
+                    </div>
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
+                      <p class="ch-headline mb-0 align-self-start">Comunidade dentro de casa</p>
+                      <p class="ch-subhead mb-0 align-self-start">Aproximação genuína com o ecossistema de tecnologia Apple — sem nenhum pagamento à organização do CocoaHeads Brasil</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row justify-content-center" style="margin-bottom: 3.5rem">
+            <div class="col-12 col-md-10 col-lg-8 col-xl-7">
+              <div class="overflow-hidden h-100" style="border-radius: 12px">
+                <div loading="lazy" class="ratio w-100" style="--bs-aspect-ratio: 56.25%">
+                  <img src="/images/parceria/community.webp" alt="Público reunido durante um evento CocoaHeads" class="object-fit-cover" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row justify-content-center" style="margin-bottom: 3.5rem">
+            <div class="col-12 col-md-10 col-lg-8 col-xl-7">
+              <div class="vstack" style="gap: 20px">
+                <div class="mb-0 align-self-start">
+                  <div class="vstack" style="gap: 6px">
                     <h2 class="mb-0 align-self-start">O que precisamos de você</h2>
                   </div>
                 </div>
@@ -269,53 +316,6 @@
                 <div class="ch-surface mb-0 align-self-start vstack" style="padding: 20px; gap: 4px">
                   <p class="ch-headline mb-0 align-self-start">Opcional, mas sempre bem-vindo</p>
                   <p class="ch-subhead mb-0 align-self-start">Acesso Wi-Fi para os participantes e coffee break ou água/café para os intervalos de networking. A organização pode buscar parceiros e patrocinadores para viabilizar o coffee break, caso o anfitrião não possa oferecê-lo.</p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="row justify-content-center" style="margin-bottom: 3.5rem">
-            <div class="col-12 col-md-10 col-lg-8 col-xl-7">
-              <div class="overflow-hidden h-100" style="border-radius: 12px">
-                <div loading="lazy" class="ratio w-100" style="--bs-aspect-ratio: 56.25%">
-                  <img src="/images/parceria/community.webp" alt="Público reunido durante um evento CocoaHeads" class="object-fit-cover" />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="row justify-content-center" style="margin-bottom: 3.5rem">
-            <div class="col-12 col-md-10 col-lg-8 col-xl-7">
-              <div class="vstack" style="gap: 20px">
-                <div class="mb-0 align-self-start">
-                  <div class="vstack" style="gap: 6px">
-                    <h2 class="mb-0 align-self-start">Por que receber um CocoaHeads</h2>
-                  </div>
-                </div>
-                <p class="mb-0 align-self-start">Receber um CocoaHeads é uma forma direta de se conectar com a comunidade de tecnologia da sua região:</p>
-                <div class="row g-3 mb-0 align-self-start">
-                  <div class="col-12 col-md-6">
-                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
-                      <p class="ch-headline mb-0 align-self-start">Networking e talentos</p>
-                      <p class="ch-subhead mb-0 align-self-start">Contato direto com desenvolvedores experientes e novos talentos da plataforma Apple — um público dedicado, que sai de casa para aprender e trocar com a comunidade</p>
-                    </div>
-                  </div>
-                  <div class="col-12 col-md-6">
-                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
-                      <p class="ch-headline mb-0 align-self-start">Visibilidade qualificada</p>
-                      <p class="ch-subhead mb-0 align-self-start">Sua marca associada ao principal encontro de desenvolvedores Apple do Brasil, diante de um público técnico e engajado</p>
-                    </div>
-                  </div>
-                  <div class="col-12 col-md-6">
-                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
-                      <p class="ch-headline mb-0 align-self-start">Espaço na agenda</p>
-                      <p class="ch-subhead mb-0 align-self-start">Um momento para apresentar sua organização, seus projetos ou oportunidades ao público presente</p>
-                    </div>
-                  </div>
-                  <div class="col-12 col-md-6">
-                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
-                      <p class="ch-headline mb-0 align-self-start">Comunidade dentro de casa</p>
-                      <p class="ch-subhead mb-0 align-self-start">Aproximação genuína com o ecossistema de tecnologia Apple — sem nenhum pagamento à organização do CocoaHeads Brasil</p>
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>

--- a/site/Sources/Pages/MeetupPartnership.swift
+++ b/site/Sources/Pages/MeetupPartnership.swift
@@ -79,9 +79,9 @@ struct MeetupPartnership: StaticPage {
                 readingRow { porQueFazemosSection }
                 readingRow { comoFuncionaSection }
                 readingRow { candidPhoto("/images/parceria/phone-speaker.webp", "Palestra técnica em andamento durante um CocoaHeads") }
-                readingRow { precisamosSection }
-                readingRow { candidPhoto("/images/parceria/community.webp", "Público reunido durante um evento CocoaHeads") }
                 readingRow { beneficiosSection }
+                readingRow { candidPhoto("/images/parceria/community.webp", "Público reunido durante um evento CocoaHeads") }
+                readingRow { precisamosSection }
                 readingRow { candidPhoto("/images/parceria/partner.webp", "Palestrante no espaço do anfitrião durante um CocoaHeads") }
                 readingRow { agendaSection }
                 readingRow { compromissosSection }


### PR DESCRIPTION
## Summary

Swaps the order of two sections on the Meetup Partnership page (`parceria-meetup`):

- **"Por que receber um CocoaHeads"** (benefits) now comes **before**
- **"O que precisamos de você"** (requirements)

The `community.webp` candid photo remains between the two sections.

## Changes

- `site/Sources/Pages/MeetupPartnership.swift`: reordered `beneficiosSection` and `precisamosSection` in the page body.
- `site/Build/parceria-meetup/index.html`: applied the matching swap to the built HTML artifact so the deployed output stays in sync.

## Notes

The Swift toolchain is unavailable in this environment (`download.swift.org` is blocked by the network policy), so `swift build` could not be run here. The generated HTML was updated by hand to mirror the source change exactly. A rebuild in CI/locally will reproduce the same output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXASk9KS6briYEgdy81jLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXASk9KS6briYEgdy81jLC)_