### PR TITLE
Invert "Como funciona um meetup" and "Por que receber" sections in MeetupPartnership

### DIFF
--- a/site/Build/parceria-meetup/index.html
+++ b/site/Build/parceria-meetup/index.html
@@ -172,6 +172,53 @@
               <div class="vstack" style="gap: 20px">
                 <div class="mb-0 align-self-start">
                   <div class="vstack" style="gap: 6px">
+                    <h2 class="mb-0 align-self-start">Por que receber um CocoaHeads</h2>
+                  </div>
+                </div>
+                <p class="mb-0 align-self-start">Receber um CocoaHeads é uma forma direta de se conectar com a comunidade de tecnologia da sua região:</p>
+                <div class="row g-3 mb-0 align-self-start">
+                  <div class="col-12 col-md-6">
+                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
+                      <p class="ch-headline mb-0 align-self-start">Networking e talentos</p>
+                      <p class="ch-subhead mb-0 align-self-start">Contato direto com desenvolvedores experientes e novos talentos da plataforma Apple — um público dedicado, que sai de casa para aprender e trocar com a comunidade</p>
+                    </div>
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
+                      <p class="ch-headline mb-0 align-self-start">Visibilidade qualificada</p>
+                      <p class="ch-subhead mb-0 align-self-start">Sua marca associada ao principal encontro de desenvolvedores Apple do Brasil, diante de um público técnico e engajado</p>
+                    </div>
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
+                      <p class="ch-headline mb-0 align-self-start">Espaço na agenda</p>
+                      <p class="ch-subhead mb-0 align-self-start">Um momento para apresentar sua organização, seus projetos ou oportunidades ao público presente</p>
+                    </div>
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
+                      <p class="ch-headline mb-0 align-self-start">Comunidade dentro de casa</p>
+                      <p class="ch-subhead mb-0 align-self-start">Aproximação genuína com o ecossistema de tecnologia Apple — sem nenhum pagamento à organização do CocoaHeads Brasil</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row justify-content-center" style="margin-bottom: 3.5rem">
+            <div class="col-12 col-md-10 col-lg-8 col-xl-7">
+              <div class="overflow-hidden h-100" style="border-radius: 12px">
+                <div loading="lazy" class="ratio w-100" style="--bs-aspect-ratio: 56.25%">
+                  <img src="/images/parceria/phone-speaker.webp" alt="Palestra técnica em andamento durante um CocoaHeads" class="object-fit-cover" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="row justify-content-center" style="margin-bottom: 3.5rem">
+            <div class="col-12 col-md-10 col-lg-8 col-xl-7">
+              <div class="vstack" style="gap: 20px">
+                <div class="mb-0 align-self-start">
+                  <div class="vstack" style="gap: 6px">
                     <h2 class="mb-0 align-self-start">Como funciona um meetup</h2>
                   </div>
                 </div>
@@ -219,53 +266,6 @@
                   </div>
                 </div>
                 <p class="mb-0 align-self-start">Toda a organização — pauta, palestrantes, inscrições, divulgação e gravação — fica por conta da equipe do CocoaHeads. O anfitrião entra com o espaço.</p>
-              </div>
-            </div>
-          </div>
-          <div class="row justify-content-center" style="margin-bottom: 3.5rem">
-            <div class="col-12 col-md-10 col-lg-8 col-xl-7">
-              <div class="overflow-hidden h-100" style="border-radius: 12px">
-                <div loading="lazy" class="ratio w-100" style="--bs-aspect-ratio: 56.25%">
-                  <img src="/images/parceria/phone-speaker.webp" alt="Palestra técnica em andamento durante um CocoaHeads" class="object-fit-cover" />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="row justify-content-center" style="margin-bottom: 3.5rem">
-            <div class="col-12 col-md-10 col-lg-8 col-xl-7">
-              <div class="vstack" style="gap: 20px">
-                <div class="mb-0 align-self-start">
-                  <div class="vstack" style="gap: 6px">
-                    <h2 class="mb-0 align-self-start">Por que receber um CocoaHeads</h2>
-                  </div>
-                </div>
-                <p class="mb-0 align-self-start">Receber um CocoaHeads é uma forma direta de se conectar com a comunidade de tecnologia da sua região:</p>
-                <div class="row g-3 mb-0 align-self-start">
-                  <div class="col-12 col-md-6">
-                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
-                      <p class="ch-headline mb-0 align-self-start">Networking e talentos</p>
-                      <p class="ch-subhead mb-0 align-self-start">Contato direto com desenvolvedores experientes e novos talentos da plataforma Apple — um público dedicado, que sai de casa para aprender e trocar com a comunidade</p>
-                    </div>
-                  </div>
-                  <div class="col-12 col-md-6">
-                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
-                      <p class="ch-headline mb-0 align-self-start">Visibilidade qualificada</p>
-                      <p class="ch-subhead mb-0 align-self-start">Sua marca associada ao principal encontro de desenvolvedores Apple do Brasil, diante de um público técnico e engajado</p>
-                    </div>
-                  </div>
-                  <div class="col-12 col-md-6">
-                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
-                      <p class="ch-headline mb-0 align-self-start">Espaço na agenda</p>
-                      <p class="ch-subhead mb-0 align-self-start">Um momento para apresentar sua organização, seus projetos ou oportunidades ao público presente</p>
-                    </div>
-                  </div>
-                  <div class="col-12 col-md-6">
-                    <div class="ch-card h-100 vstack" style="padding: 20px; gap: 8px">
-                      <p class="ch-headline mb-0 align-self-start">Comunidade dentro de casa</p>
-                      <p class="ch-subhead mb-0 align-self-start">Aproximação genuína com o ecossistema de tecnologia Apple — sem nenhum pagamento à organização do CocoaHeads Brasil</p>
-                    </div>
-                  </div>
-                </div>
               </div>
             </div>
           </div>

--- a/site/Sources/Pages/MeetupPartnership.swift
+++ b/site/Sources/Pages/MeetupPartnership.swift
@@ -77,9 +77,9 @@ struct MeetupPartnership: StaticPage {
                 readingRow { quemSomos }
                 wideRow { photoMosaic }
                 readingRow { porQueFazemosSection }
-                readingRow { comoFuncionaSection }
-                readingRow { candidPhoto("/images/parceria/phone-speaker.webp", "Palestra técnica em andamento durante um CocoaHeads") }
                 readingRow { beneficiosSection }
+                readingRow { candidPhoto("/images/parceria/phone-speaker.webp", "Palestra técnica em andamento durante um CocoaHeads") }
+                readingRow { comoFuncionaSection }
                 readingRow { candidPhoto("/images/parceria/community.webp", "Público reunido durante um evento CocoaHeads") }
                 readingRow { precisamosSection }
                 readingRow { candidPhoto("/images/parceria/partner.webp", "Palestrante no espaço do anfitrião durante um CocoaHeads") }


### PR DESCRIPTION
## Summary

Swaps the order of two sections on the Meetup Partnership page (`parceria-meetup`):

- **"Por que receber um CocoaHeads"** (benefits) now comes **before**
- **"Como funciona um meetup"** (format)

The phone-speaker candid photo remains between the two sections.

Resulting section order on the page:

1. Por que fazemos o que fazemos?
2. Por que receber um CocoaHeads
3. Como funciona um meetup
4. O que precisamos de você

## Changes

- `site/Sources/Pages/MeetupPartnership.swift`: reordered `beneficiosSection` and `comoFuncionaSection` in the page body.
- `site/Build/parceria-meetup/index.html`: applied the matching swap to the built HTML artifact so the deployed output stays in sync.

## Notes

The Swift toolchain is unavailable in this environment (`download.swift.org` is blocked by the network policy), so `swift build` could not be run here. The generated HTML was updated by hand to mirror the source change exactly. A rebuild in CI/locally will reproduce the same output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXASk9KS6briYEgdy81jLC

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXASk9KS6briYEgdy81jLC)_