### PR TITLE
Add OpenGraph tags to meetup partnership page

### DIFF
--- a/site/Build/parceria-meetup/index.html
+++ b/site/Build/parceria-meetup/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Conheça a maior comunidade de desenvolvimento Apple da América Latina e como funciona uma parceria para meetups" />
     <meta name="author" content="CocoaHeads Brasil" />
     <meta name="generator" content="Ignite v0.6.9" />
     <title>Proposta de Parceria – Olá Mundo!</title>
@@ -56,8 +57,12 @@
 })();
 </script>
     <meta property="og:site_name" content="CocoaHeads Brasil" />
+    <meta property="og:image" content="https://www.cocoaheads.com.br/images/parceria/hero.webp" />
+    <meta name="twitter:image" content="https://www.cocoaheads.com.br/images/parceria/hero.webp" />
     <meta property="og:title" content="Proposta de Parceria" />
     <meta name="twitter:title" content="Proposta de Parceria" />
+    <meta property="og:description" content="Conheça a maior comunidade de desenvolvimento Apple da América Latina e como funciona uma parceria para meetups" />
+    <meta name="twitter:description" content="Conheça a maior comunidade de desenvolvimento Apple da América Latina e como funciona uma parceria para meetups" />
     <meta property="og:url" content="https://www.cocoaheads.com.br/parceria-meetup" />
     <meta name="twitter:domain" content="cocoaheads.com.br" />
     <meta name="twitter:card" content="summary_large_image" />

--- a/site/Sources/Pages/MeetupPartnership.swift
+++ b/site/Sources/Pages/MeetupPartnership.swift
@@ -4,6 +4,8 @@ import Ignite
 struct MeetupPartnership: StaticPage {
     var title = "Proposta de Parceria"
     var path: String = "parceria-meetup"
+    var description = "Conheça a maior comunidade de desenvolvimento Apple da América Latina e como funciona uma parceria para meetups"
+    var image: URL? = URL(static: "https://www.cocoaheads.com.br/images/parceria/hero.webp")
 
     // MARK: - Content
 


### PR DESCRIPTION
## Summary

Adds OpenGraph / Twitter Card metadata to the meetup partnership page (`parceria-meetup`) so it renders a rich preview when shared on social media and messaging apps.

Sets the page's `image` and `description` properties, which Ignite's `socialSharingTags()` uses to emit:

- `og:image` / `twitter:image` → `hero.webp`
- `og:description` / `twitter:description` → a plain-text summary of the partnership proposal

The page already had `twitter:card` set to `summary_large_image`, but was missing the image and description those previews depend on.

## Changes

- `site/Sources/Pages/MeetupPartnership.swift` — add `image` and `description`
- `site/Build/parceria-meetup/index.html` — regenerated static output

## Verification

`swift build` and `swift run` (publish) both succeed, and the generated HTML now contains the `og:image`, `og:description`, `twitter:image`, and `twitter:description` meta tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)